### PR TITLE
Support alternate namespace for log method.

### DIFF
--- a/remote_console.js
+++ b/remote_console.js
@@ -57,13 +57,16 @@ function parseJson(string){
 
 function returnDebugJS(ns){
     ns = ns || "window";
-    return '(function(){var log=function(){log.history=log.history||[];log.history.push(arguments);' + 
-    'var message=Array.prototype.slice.call(arguments),args=JSON.stringify(message), ' + 
-    'img=document.createElement("img"),url="http://'+host+':'+port+'/?console="+escape(args);' + 
-    'img.src=url;img.style.display="none";document.body.appendChild(img);' + 
-    'if(this.console){console.log(Array.prototype.slice.call(arguments))}};catchRemote=function' +
-    '(func){try{func();}catch(e){log({"error":e});}};' + ns + '.log=log;})()';
-    
+    return '\n\
+    (function(){ \n\
+        var log=function(obj) { \n\
+            var str = JSON.stringify(obj); \n\
+            var img = document.createElement("img"); \n\
+            var url = "http://' + host + ':' + port + '/?console=" + encodeURIComponent(str); \n\
+            img.src = url; \n\
+        } \n\
+        ' + ns + '.log = log; \n\
+    })()';    
 }
 
 http.createServer(function (req, res) {

--- a/remote_console.js
+++ b/remote_console.js
@@ -60,7 +60,7 @@ function returnDebugJS(ns){
     return '(function(){var log=function(){log.history=log.history||[];log.history.push(arguments);' + 
     'var message=Array.prototype.slice.call(arguments),args=JSON.stringify(message), ' + 
     'img=document.createElement("img"),url="http://'+host+':'+port+'/?console="+escape(args);' + 
-    'document.write(message);img.src=url;img.style.display="none";document.body.appendChild(img);' + 
+    'img.src=url;img.style.display="none";document.body.appendChild(img);' + 
     'if(this.console){console.log(Array.prototype.slice.call(arguments))}};catchRemote=function' +
     '(func){try{func();}catch(e){log({"error":e});}};' + ns + '.log=log;})()';
     

--- a/remote_console.js
+++ b/remote_console.js
@@ -55,13 +55,14 @@ function parseJson(string){
     }
 };
 
-function returnDebugJS(){
-    return 'window.log=function(){log.history=log.history||[];log.history.push(arguments);' + 
+function returnDebugJS(ns){
+    ns = ns || "window";
+    return '(function(){var log=function(){log.history=log.history||[];log.history.push(arguments);' + 
     'var message=Array.prototype.slice.call(arguments),args=JSON.stringify(message), ' + 
     'img=document.createElement("img"),url="http://'+host+':'+port+'/?console="+escape(args);' + 
     'document.write(message);img.src=url;img.style.display="none";document.body.appendChild(img);' + 
     'if(this.console){console.log(Array.prototype.slice.call(arguments))}};catchRemote=function' +
-    '(func){try{func();}catch(e){log({"error":e});}};';
+    '(func){try{func();}catch(e){log({"error":e});}};' + ns + '.log=log;})()';
     
 }
 
@@ -71,9 +72,10 @@ http.createServer(function (req, res) {
           parseJson(brokeDownRequest.query.console) :
           "No console passed";
           
-    if(req.url == "/debug.js"){
+    if(req.url.indexOf("/debug.js") === 0){
+        var ns = brokeDownRequest.query && brokeDownRequest.query.ns || "";
         res.writeHead(200, {'Content-Type': 'text/javascript'});
-        res.end(returnDebugJS());
+        res.end(returnDebugJS(ns));
         return;
     } 
     if(req.url == "/favicon.ico"){


### PR DESCRIPTION
It would be nice for users to be able to decide the namespace for the log method (particularly for pages that already have window.log).  These changes allow log to be assigned to an arbitrary namespace by loading the debug.js script with an "ns" query string parameter.

E.g. 

```
    <script src="http://127.0.0.1:8124/debug.js?ns=My.Console"></script>
```

In addition, I've removed the `document.write` call because this was breaking iOS browsers.
